### PR TITLE
fix compute_metrics if model is mixtral, if not --> error

### DIFF
--- a/functionary/train/train_lora.py
+++ b/functionary/train/train_lora.py
@@ -510,8 +510,16 @@ def train():
             args=training_args,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            compute_metrics=compute_metrics,
-            preprocess_logits_for_metrics=preprocess_logits_for_metrics,
+            compute_metrics=(
+                compute_metrics
+                if "mixtral" not in model_args.model_name_or_path.lower()
+                else None
+            ),
+            preprocess_logits_for_metrics=(
+                preprocess_logits_for_metrics
+                if "mixtral" not in model_args.model_name_or_path.lower()
+                else None
+            ),
         )
     else:
         trainer = Trainer(


### PR DESCRIPTION
+ if model is mixtral, using current compute_metrics would result in error, so we set compute_metrics=None if model is mixtral