### PR TITLE
Implement streaming request handling unittest

### DIFF
--- a/functionary/prompt_template/base_template.py
+++ b/functionary/prompt_template/base_template.py
@@ -228,6 +228,10 @@ class PromptTemplate:
         """
         raise NotImplementedError
 
+    def get_tool_choice_required_prefix(self):
+        """This function will be used when tool_choice='required'. Returns empty string by default"""
+        return ""
+
     def get_raw_response_from_assistant_message(
         self,
         message: Dict[str, Any],
@@ -259,6 +263,8 @@ class PromptTemplate:
 
         if tool_func_choice == "none":
             raw_response = raw_response[len(self.get_force_text_generation_prefix()) :]
+        elif tool_func_choice == "required":
+            raw_response = raw_response[len(self.get_tool_choice_required_prefix()) :]
         elif isinstance(tool_func_choice, Tool) or isinstance(
             tool_func_choice, Function
         ):
@@ -270,7 +276,7 @@ class PromptTemplate:
                 ) :
             ]
 
-        return raw_response
+        return raw_response.rstrip()
 
     @abstractmethod
     def get_chat_template_jinja(self):

--- a/functionary/prompt_template/llama3_prompt_template.py
+++ b/functionary/prompt_template/llama3_prompt_template.py
@@ -28,6 +28,7 @@ class Llama3Template(PromptTemplate):
     function_separator = "<|reserved_special_token_249|>"
     version = "v2.llama3"
     fn_param_sep_token = "\n"
+    tokenizer_name_or_path = "meetkai/functionary-small-v2.5"
 
     def get_additional_tokens(self) -> List[str]:
         return []
@@ -563,3 +564,6 @@ class Llama3Template(PromptTemplate):
 
     def get_force_function_call_prefix(self, function_name: str):
         return f"{self.function_separator}{function_name}\n"
+
+    def get_tool_choice_required_prefix(self):
+        return self.function_separator

--- a/functionary/prompt_template/llama3_prompt_template.py
+++ b/functionary/prompt_template/llama3_prompt_template.py
@@ -28,7 +28,6 @@ class Llama3Template(PromptTemplate):
     function_separator = "<|reserved_special_token_249|>"
     version = "v2.llama3"
     fn_param_sep_token = "\n"
-    tokenizer_name_or_path = "meetkai/functionary-small-v2.5"
 
     def get_additional_tokens(self) -> List[str]:
         return []
@@ -297,7 +296,7 @@ class Llama3Template(PromptTemplate):
                 self.get_force_function_call_prefix(tool_choice_name) + llm_output
             )
         elif tool_choice == "required":
-            llm_output = self.function_separator + llm_output
+            llm_output = self.get_tool_choice_required_prefix() + llm_output
 
         chunks = llm_output.split(self.function_separator)
         chunks = [chunk.strip() for chunk in chunks if len(chunk.strip()) > 0]

--- a/functionary/prompt_template/prompt_template_v2.py
+++ b/functionary/prompt_template/prompt_template_v2.py
@@ -16,7 +16,6 @@ class PromptTemplateV2(PromptTemplate):
     version = "v2"
     # This token splits between function name and parameters
     fn_param_sep_token = "\n<|content|>"
-    tokenizer_name_or_path = "meetkai/functionary-small-v2.4"
 
     def get_start_of_function_call_token(self) -> str:
         return self.recipient_token

--- a/functionary/prompt_template/prompt_template_v2.py
+++ b/functionary/prompt_template/prompt_template_v2.py
@@ -16,6 +16,7 @@ class PromptTemplateV2(PromptTemplate):
     version = "v2"
     # This token splits between function name and parameters
     fn_param_sep_token = "\n<|content|>"
+    tokenizer_name_or_path = "meetkai/functionary-small-v2.4"
 
     def get_start_of_function_call_token(self) -> str:
         return self.recipient_token
@@ -427,6 +428,28 @@ class PromptTemplateV2(PromptTemplate):
         chat_template = chat_template.strip()
         return chat_template
 
+    def update_state_for_text(self, current_state):
+        """update the state when a function is going to be called
+
+        Args:
+            current_state (_type_): _description_
+        """
+        current_state["response_type"] = "text"
+        current_state["skip_until_reach"] = ""
+        current_state["current_text"] = ""
+
+    def update_state_for_function(self, current_state):
+        """update the state when a function is going to be called
+
+        Args:
+            current_state (_type_): _description_
+        """
+        current_state["response_type"] = "function"
+        current_state["skip_until_reach"] = ""
+        current_state["current_text"] = ""
+        current_state["func_index"] += 1
+        current_state["call_id"] = prompt_utils.get_random_tool_call_id()
+
     def update_response_state_from_delta_text(
         self,
         *,
@@ -435,52 +458,63 @@ class PromptTemplateV2(PromptTemplate):
         finish_reason: Optional[str],
         tool_choice: Any,
     ) -> Tuple[Dict[str, Any], Union[None, Dict, List[Dict]]]:
-        func_name = None
-        response_type = None
-        skip_until_reach = ""
 
         if len(current_state) == 0:  # empty dict, at the first_time
-            response_type, skip_until_reach, func_name = None, self.content_token, None
+            current_state = {
+                "current_text": "",  # the concatenation of all tokens so far
+                "func_name": None,  # function_name of the current tool, if the response requires to use tool
+                "response_type": None,  # response_type=text(text response)/function (using tool)
+                "func_index": -1,  # index of the tool in tool_calls
+                "call_id": None,  # call_id of the current tool
+                # skip_until_reach we skip new tokens until we reach certain token. This is used when we hit special tokens
+                "skip_until_reach": self.content_token,  # at first we don't need to skip as we are generating function
+                "first_time": True,  # if first_time we return an tempty delta with role=assistant
+                "prev_whitespaces": 0,  # number of consecutive whitespaces prior to this token
+            }
 
             if tool_choice == "none":
-                response_type, skip_until_reach = "text", ""
-                func_name = "all"
-            elif (
-                type(tool_choice) is not str and tool_choice is not None
-            ):  # tool_choice is a specific tool
-                response_type, skip_until_reach = "function", ""
-                func_name = (
+                self.update_state_for_text(current_state=current_state)
+
+            elif type(tool_choice) is not str and tool_choice is not None:
+                self.update_state_for_function(current_state=current_state)
+                current_state["func_name"] = (
                     tool_choice.function.name
                     if isinstance(tool_choice, Tool)
                     else tool_choice.name
                 )
+                current_state["current_text"] += delta_text
+                # first return a delta with function_name only
+                responses = [
+                    prompt_utils.get_function_delta_response(
+                        current_state, "", True, False, finish_reason
+                    )
+                ]
+                # next return the first chunk of params
+                responses.append(
+                    prompt_utils.get_function_delta_response(
+                        current_state, delta_text, False, False, finish_reason
+                    )
+                )
+                return current_state, responses
+        else:
+            current_state["first_time"] = False
 
-            current_state = {
-                "current_text": "",  # the concatenation of all tokens so far
-                "func_name": func_name,  # function_name of the current tool, if the response requires to use tool
-                "response_type": response_type,  # response_type=text(text response)/function (using tool)
-                "func_index": -1,  # index of the tool in tool_calls
-                "call_id": None,  # call_id of the current tool
-                # skip_until_reach we skip new tokens until we reach certain token. This is used when we hit special tokens
-                "skip_until_reach": skip_until_reach,  # at first we don't need to skip as we are generating function
-                "first_time": True,  # if first_time we return an tempty delta with role=assistant
-            }
         # check if previous token is <|content|>, there might be a space between this token and next token (ex, <|content|> Hello)
         if current_state["current_text"].endswith(self.content_token):
             if delta_text[0] == " ":
                 delta_text = delta_text[1:]
 
         current_state["current_text"] += delta_text
-        if finish_reason is not None:
+
+        if finish_reason is not None:  # handle if finish
             if current_state["response_type"] == "function":
                 finish_reason = "tool_calls"
-
             return current_state, prompt_utils.get_text_delta_response(
                 None, False, finish_reason
             )
 
         skip_until_reach = current_state.get("skip_until_reach", "")
-        if skip_until_reach:
+        if skip_until_reach:  # if have to wait
             if delta_text != skip_until_reach:
                 return current_state, None
             else:
@@ -507,40 +541,63 @@ class PromptTemplateV2(PromptTemplate):
             assert current_state["response_type"] is not None
 
             first_time = current_state["first_time"]
-            if (
-                delta_text == self.from_token
-            ):  # skip until reach <content> to check type of response
+            # If the model is generating a new assistant turn
+            if delta_text == "\n":
+                current_state["prev_whitespaces"] += 1
+                return current_state, None
+            elif (
+                delta_text == self.from_token and current_state["prev_whitespaces"] > 0
+            ):
                 current_state["current_text"] = ""
                 current_state["skip_until_reach"] = self.content_token
                 current_state["response_type"] = None
-                return current_state, None
-
+                responses = None
+                if current_state["prev_whitespaces"] > 1:
+                    for _ in range(1, current_state["prev_whitespaces"]):
+                        if current_state["response_type"] == "text":
+                            responses.append(
+                                prompt_utils.get_text_delta_response(
+                                    "\n", True, finish_reason
+                                )
+                            )
+                        else:
+                            responses.append(
+                                prompt_utils.get_function_delta_response(
+                                    current_state, "\n", False, False, finish_reason
+                                )
+                            )
+                current_state["prev_whitespaces"] = 0
+                return current_state, responses
+            # Continue generating delta_text
             else:
+                responses = []
                 if current_state["response_type"] == "function":
                     if first_time:
                         current_state["call_id"] = (
                             prompt_utils.get_random_tool_call_id()
                         )
                         current_state["func_index"] += 1
-                        responses = []
                         responses.append(
                             prompt_utils.get_function_delta_response(
                                 current_state, "", first_time, False, finish_reason
                             )
                         )
                         current_state["first_time"] = False
-                        responses.append(
-                            prompt_utils.get_function_delta_response(
-                                current_state, delta_text, False, False, finish_reason
+                    if current_state["prev_whitespaces"] > 0:
+                        for _ in range(current_state["prev_whitespaces"]):
+                            responses.append(
+                                prompt_utils.get_function_delta_response(
+                                    current_state, "\n", False, False, finish_reason
+                                )
                             )
-                        )
-                    else:
-                        responses = prompt_utils.get_function_delta_response(
+                        current_state["prev_whitespaces"] = 0
+                    responses.append(
+                        prompt_utils.get_function_delta_response(
                             current_state, delta_text, False, False, finish_reason
                         )
+                    )
                     return current_state, responses
                 else:  # response_type=text
-                    responses = []
                     if first_time:
                         current_state["first_time"] = False
                         responses.append(
@@ -548,6 +605,14 @@ class PromptTemplateV2(PromptTemplate):
                                 "", True, finish_reason
                             )
                         )
+                    if current_state["prev_whitespaces"] > 0:
+                        for _ in range(current_state["prev_whitespaces"]):
+                            responses.append(
+                                prompt_utils.get_text_delta_response(
+                                    "\n", True, finish_reason
+                                )
+                            )
+                        current_state["prev_whitespaces"] = 0
                     responses.append(
                         prompt_utils.get_text_delta_response(
                             delta_text, True, finish_reason
@@ -561,3 +626,6 @@ class PromptTemplateV2(PromptTemplate):
 
     def get_force_function_call_prefix(self, function_name: str):
         return f"{function_name}{self.fn_param_sep_token}"
+
+    def get_tool_choice_required_prefix(self):
+        return ""

--- a/tests/test_request_handling.py
+++ b/tests/test_request_handling.py
@@ -1,19 +1,25 @@
 import json
 import unittest
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 from fastapi.responses import JSONResponse
 from transformers import AutoTokenizer
 
+from functionary.inference_stream import generate_openai_format_from_stream_async
 from functionary.openai_types import (
     ChatCompletionRequest,
     ChatCompletionResponseChoice,
     ChatMessage,
     Function,
+    FunctionCall,
+    StreamChoice,
     Tool,
 )
-from functionary.prompt_template import get_available_prompt_template_versions
+from functionary.prompt_template import (
+    PromptTemplate,
+    get_available_prompt_template_versions,
+)
 from functionary.prompt_template.prompt_utils import (
     enforce_tool_choice,
     prepare_messages_for_inference,
@@ -111,6 +117,39 @@ def get_token_ids_from_request(
     ).tolist()[0]
 
     return prompt_token_ids
+
+
+def generate_raw_response(
+    gen_text: bool,
+    num_tool_calls: Optional[int],
+    tool_func_choice: Union[str, Tool, Function],
+    default_text_str: str,
+    default_tool_call_name: str,
+    default_tool_call_args: List[str],
+    prompt_template: PromptTemplate,
+):
+    message = {"role": "assistant"}
+    if gen_text:
+        message["content"] = default_text_str
+    if num_tool_calls is not None:
+        tool_calls = []
+        for tool_call_args in default_tool_call_args[:num_tool_calls]:
+            tool_calls.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": default_tool_call_name,
+                        "arguments": tool_call_args,
+                    },
+                }
+            )
+        message["tool_calls"] = tool_calls
+
+    return prompt_template.get_raw_response_from_assistant_message(
+        message=message,
+        tool_func_choice=tool_func_choice,
+        default_tool_call_name=default_tool_call_name,
+    )
 
 
 class TestRequestHandling(unittest.IsolatedAsyncioTestCase):
@@ -428,40 +467,16 @@ class TestRequestHandling(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_request_handling(self):
-        def generate_raw_response(
-            gen_text: bool,
-            num_tool_calls: Optional[int],
-            tool_func_choice: Union[str, Tool, Function],
-        ):
-            message = {"role": "assistant"}
-            if gen_text:
-                message["content"] = self.default_text_str
-            if num_tool_calls is not None:
-                tool_calls = []
-                for tool_call_args in self.default_tool_call_args[:num_tool_calls]:
-                    tool_calls.append(
-                        {
-                            "type": "function",
-                            "function": {
-                                "name": self.default_tool_call_name,
-                                "arguments": tool_call_args,
-                            },
-                        }
-                    )
-                message["tool_calls"] = tool_calls
-
-            return prompt_template.get_raw_response_from_assistant_message(
-                message=message,
-                tool_func_choice=tool_func_choice,
-                default_tool_call_name=self.default_tool_call_name,
-            )
-
         for prompt_template in self.test_prompt_templates:
             for test_case in self.request_handling_test_cases:
                 raw_response = generate_raw_response(
                     gen_text=test_case["gen_text"],
                     num_tool_calls=test_case["num_tool_calls"],
                     tool_func_choice=test_case["tool_func_choice"],
+                    default_text_str=self.default_text_str,
+                    default_tool_call_name=self.default_tool_call_name,
+                    default_tool_call_args=self.default_tool_call_args,
+                    prompt_template=prompt_template,
                 )
                 chat_mess = prompt_template.parse_assistant_response(
                     llm_output=raw_response, tool_choice=test_case["tool_func_choice"]
@@ -510,6 +525,125 @@ class TestRequestHandling(unittest.IsolatedAsyncioTestCase):
                     test_case["expected_finish_reason"],
                     f"Wrong finish reason for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
                 )
+
+    async def test_request_handling_streaming(self):
+        async def wrap_generator(tokenizer, raw_response, test_case):
+            tokenized_response = tokenizer.encode(
+                raw_response, add_special_tokens=False
+            )
+            # Append None to the end to produce finish_reason
+            tokenized_response.append(None)
+
+            prev_ids = []
+            for token_id in tokenized_response:
+                if token_id is not None:
+                    offset = tokenizer.decode(prev_ids + [token_id])[
+                        len(tokenizer.decode(prev_ids)) :
+                    ]
+                    prev_ids.append(token_id)
+                    yield offset, None
+                else:
+                    yield "", test_case["expected_finish_reason"]
+
+        for prompt_template in self.test_prompt_templates:
+            tokenizer = AutoTokenizer.from_pretrained(
+                prompt_template.tokenizer_name_or_path
+            )
+            for test_case in self.request_handling_test_cases:
+                raw_response = generate_raw_response(
+                    gen_text=test_case["gen_text"],
+                    num_tool_calls=test_case["num_tool_calls"],
+                    tool_func_choice=test_case["tool_func_choice"],
+                    default_text_str=self.default_text_str,
+                    default_tool_call_name=self.default_tool_call_name,
+                    default_tool_call_args=self.default_tool_call_args,
+                    prompt_template=prompt_template,
+                )
+                # Use tokenizer to split raw response into chunks
+                generator = wrap_generator(tokenizer, raw_response, test_case)
+
+                content = ""
+                tool_calls = []
+                tool_call_count = 0
+                chunks_list = []
+                async for response in generate_openai_format_from_stream_async(
+                    generator, prompt_template, test_case["tool_func_choice"]
+                ):
+                    chunk = StreamChoice(**response)
+                    if chunk.delta.content is not None:
+                        content += chunk.delta.content
+                    if chunk.delta.tool_calls is not None:
+                        name = chunk.delta.tool_calls[0].function.name
+                        arguments = chunk.delta.tool_calls[0].function.arguments
+                        # Convert chunk's tool_calls into function_call
+                        if test_case["expected_finish_reason"] == "function_call":
+                            chunk.delta.function_call = FunctionCall(
+                                name=name, arguments=arguments
+                            )
+                            chunk.delta.tool_calls = None
+                            if name is not None and len(name) > 0:
+                                tool_call_count += 1
+                            # Do not process the second tool call onwards for function_call
+                            if tool_call_count == 2:
+                                continue
+                        if name is not None:
+                            tool_calls.append({"name": name, "arguments": arguments})
+                        else:
+                            try:
+                                tool_calls[-1]["arguments"] += arguments
+                            except:
+                                breakpoint()
+                    chunks_list.append(chunk)
+
+                # Test content
+                label_content = self.default_text_str if test_case["gen_text"] else ""
+                self.assertEqual(
+                    content,
+                    label_content,
+                    f"Wrong streamed content for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                )
+                # Test tool_calls
+                if test_case["expected_finish_reason"] == "tool_calls":
+                    for tool_call in tool_calls:
+                        self.assertEqual(
+                            tool_call["name"],
+                            self.default_tool_call_name,
+                            f"Wrong streamed tool call name for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                        )
+                        self.assertIn(
+                            tool_call["arguments"],
+                            self.default_tool_call_args,
+                            f"Wrong streamed tool call args for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                        )
+                # Test function_call
+                elif test_case["expected_finish_reason"] == "function_call":
+                    self.assertEqual(
+                        len(tool_calls),
+                        1,
+                        f"More than 1 tool call for function_call for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                    )
+                    self.assertEqual(
+                        tool_calls[0]["name"],
+                        self.default_tool_call_name,
+                        f"Wrong streamed fn call name for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                    )
+                    self.assertIn(
+                        tool_calls[0]["arguments"],
+                        self.default_tool_call_args,
+                        f"Wrong streamed fn call args for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                    )
+                # Test finish_reason at last chunk and None for all preceding chunks
+                self.assertNotEqual(
+                    chunks_list[-1].finish_reason,
+                    None,
+                    f"Wrong streamed finish_reason for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                )
+                for chunk in chunks_list[:-1]:
+                    self.assertEqual(
+                        chunk.finish_reason,
+                        None,
+                        f"finish_reason should be None for all chunks except last for version: {prompt_template.version} | test: `{test_case['test_aim']}`",
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Previous implementation checks for `<|from|>` to start the next turn but there is an additional `\n` prior to this. Thus, this \n was always streamed to the client unnecessarily.
  - Edited to check for `\n` first and add it to a buffer called `current_state["prev_whitespaces"]`. This variable will be an integer indicating the number of consecutive `\n` encountered at the moment.
  - Do not stream the chunk to the client if the `delta_text = "\n"` and check for presence of `<|from|>` right after `\n` instead.