### PR TITLE
Migrate vllm to v0.5.0

### DIFF
--- a/functionary/vllm_inference.py
+++ b/functionary/vllm_inference.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, Un
 from fastapi import BackgroundTasks, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from vllm.entrypoints.openai.protocol import ErrorResponse
+from vllm.inputs import TokensPrompt
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
@@ -203,20 +204,18 @@ async def process_chat_completion(
 
     if enable_grammar_sampling:
         result_generator = engine.generate(
-            prompt=None,
+            inputs=TokensPrompt(prompt_token_ids=prompt_token_ids),
             sampling_params=sampling_params,
             request_id=request_id,
-            prompt_token_ids=prompt_token_ids,
             tools_or_functions=tools_or_functions,
             prompt_template_cls=prompt_template,
             tool_choice=tool_func_choice,
         )
     else:
         result_generator = engine.generate(
-            prompt=None,
+            inputs=TokensPrompt(prompt_token_ids=prompt_token_ids),
             sampling_params=sampling_params,
             request_id=request_id,
-            prompt_token_ids=prompt_token_ids,
         )
 
     async def abort_request() -> None:

--- a/functionary/vllm_monkey_patch/async_llm_engine.py
+++ b/functionary/vllm_monkey_patch/async_llm_engine.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import time
 from functools import partial
 from typing import (
@@ -16,16 +15,20 @@ from typing import (
     Union,
 )
 
+import vllm.envs as envs
 from transformers import PreTrainedTokenizer
-from vllm.config import ModelConfig
+from vllm.config import DecodingConfig, ModelConfig
+from vllm.core.scheduler import SchedulerOutputs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.llm_engine import LLMEngine
-from vllm.engine.ray_utils import initialize_ray_cluster, ray
+from vllm.executor.ray_utils import initialize_ray_cluster, ray
+from vllm.inputs import LLMInputs, PromptInputs
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.outputs import RequestOutput
+from vllm.outputs import EmbeddingRequestOutput, RequestOutput
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
-from vllm.sequence import MultiModalData
+from vllm.sequence import ExecuteModelRequest, SamplerOutput
 from vllm.usage.usage_lib import UsageContext
 
 from functionary.inference import (
@@ -34,47 +37,56 @@ from functionary.inference import (
 from functionary.openai_types import Tool
 
 logger = init_logger(__name__)
-ENGINE_ITERATION_TIMEOUT_S = int(
-    os.environ.get("VLLM_ENGINE_ITERATION_TIMEOUT_S", "60")
-)
+ENGINE_ITERATION_TIMEOUT_S = envs.VLLM_ENGINE_ITERATION_TIMEOUT_S
 
 
 class AsyncEngineDeadError(RuntimeError):
     pass
 
 
-def _raise_exception_on_finish(
+def _log_task_completion(
     task: asyncio.Task, error_callback: Callable[[Exception], None]
 ) -> None:
-    msg = (
-        "Task finished unexpectedly. This should never happen! "
-        "Please open an issue on Github."
-    )
+    """This function is only intended for the `engine.run_engine_loop()` task.
+
+    In particular, that task runs a `while True` loop that can only exit if
+    there is an exception.
+    """
 
     exception = None
     try:
-        task.result()
-        # NOTE: This will be thrown if task exits normally (which it should not)
-        raise AsyncEngineDeadError(msg)
+        return_value = task.result()
+        raise AssertionError(
+            f"The engine background task should never finish without an "
+            f"exception. {return_value}"
+        )
+    except asyncio.exceptions.CancelledError:
+        # We assume that if the task is cancelled, we are gracefully shutting
+        # down. This should only happen on program exit.
+        logger.info("Engine is gracefully shutting down.")
     except Exception as e:
         exception = e
         logger.error("Engine background task failed", exc_info=e)
         error_callback(exception)
         raise AsyncEngineDeadError(
-            msg + " See stack trace above for the actual cause."
+            "Task finished unexpectedly. This should never happen! "
+            "Please open an issue on Github. See stack trace above for the"
+            "actual cause."
         ) from e
 
 
 class AsyncStream:
-    """A stream of RequestOutputs for a request that can be
-    iterated over asynchronously."""
+    """A stream of RequestOutputs or EmbeddingRequestOutputs for a request
+    that can be iterated over asynchronously."""
 
     def __init__(self, request_id: str) -> None:
         self.request_id = request_id
-        self._queue = asyncio.Queue()
+        self._queue: asyncio.Queue = asyncio.Queue()
         self._finished = False
 
-    def put(self, item: Union[RequestOutput, Exception]) -> None:
+    def put(
+        self, item: Union[RequestOutput, EmbeddingRequestOutput, Exception]
+    ) -> None:
         if self._finished:
             return
         self._queue.put_nowait(item)
@@ -90,7 +102,7 @@ class AsyncStream:
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> RequestOutput:
+    async def __anext__(self) -> Union[RequestOutput, EmbeddingRequestOutput]:
         result = await self._queue.get()
         if isinstance(result, Exception):
             raise result
@@ -126,7 +138,10 @@ class RequestTracker:
                 self.abort_request(rid)
 
     def process_request_output(
-        self, request_output: RequestOutput, *, verbose: bool = False
+        self,
+        request_output: Union[RequestOutput, EmbeddingRequestOutput],
+        *,
+        verbose: bool = False,
     ) -> None:
         """Process a request output from the engine."""
         request_id = request_output.request_id
@@ -134,7 +149,7 @@ class RequestTracker:
         self._request_streams[request_id].put(request_output)
         if request_output.finished:
             if verbose:
-                logger.info(f"Finished request {request_id}.")
+                logger.info("Finished request %s.", request_id)
             self.abort_request(request_id)
 
     def process_exception(
@@ -143,7 +158,7 @@ class RequestTracker:
         """Propagate an exception from the engine."""
         self._request_streams[request_id].put(exception)
         if verbose:
-            logger.info(f"Finished request {request_id}.")
+            logger.info("Finished request %s.", request_id)
         self.abort_request(request_id)
 
     def add_request(self, request_id: str, **engine_add_request_kwargs) -> AsyncStream:
@@ -164,7 +179,7 @@ class RequestTracker:
     def abort_request(self, request_id: str, *, verbose: bool = False) -> None:
         """Abort a request during next background loop iteration."""
         if verbose:
-            logger.info(f"Aborted request {request_id}.")
+            logger.info("Aborted request %s.", request_id)
 
         self._finished_requests.put_nowait(request_id)
 
@@ -218,7 +233,7 @@ class _AsyncLLMEngine(LLMEngine):
     # This is a dict mappingg request_id to the generation_state. It contains
     # the following information:
     # - stage: one of the following:
-    # ["pre-function", "function", "pre-parameter", "parameter-name", "parameter-value", "no-function-call"]
+    # ["pre-function", "function", "pre-parameter", "parameter", "text-gen"]
     # - curr_tokens: all the tokens for the current stage being generated
     # - curr_text: curr_tokens but in string text form
     # - func_name: the function name, if any
@@ -267,12 +282,15 @@ class _AsyncLLMEngine(LLMEngine):
 
         if not scheduler_outputs.is_empty():
             # Execute the model.
-            output = await self.model_executor.execute_model_async(
-                seq_group_metadata_list,
-                scheduler_outputs.blocks_to_swap_in,
-                scheduler_outputs.blocks_to_swap_out,
-                scheduler_outputs.blocks_to_copy,
+            execute_model_req = ExecuteModelRequest(
+                seq_group_metadata_list=seq_group_metadata_list,
+                blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
+                blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
+                blocks_to_copy=scheduler_outputs.blocks_to_copy,
+                num_lookahead_slots=scheduler_outputs.num_lookahead_slots,
+                running_queue_size=scheduler_outputs.running_queue_size,
             )
+            output = await self.model_executor.execute_model_async(execute_model_req)
         else:
             output = []
 
@@ -316,35 +334,61 @@ class _AsyncLLMEngine(LLMEngine):
             # Update the output token to vllm with the newly sampled one
             output[i].outputs[-1].samples[-1].output_token = grammar_sampled_token_id
 
-        return self._process_model_outputs(
+        request_outputs = self._process_model_outputs(
             output,
             scheduler_outputs.scheduled_seq_groups,
             scheduler_outputs.ignored_seq_groups,
+            seq_group_metadata_list,
         )
 
-    async def encode_request_async(
+        # Log stats.
+        self.do_log_stats(scheduler_outputs, output)
+
+        if not request_outputs:
+            # Stop the execute model loop in parallel workers until there are
+            # more requests to process. This avoids waiting indefinitely in
+            # torch.distributed ops which may otherwise timeout, and unblocks
+            # the RPC thread in the workers so that they can process any other
+            # queued control plane messages, such as add/remove lora adapters.
+            await self.model_executor.stop_remote_worker_execution_loop_async()
+
+        return request_outputs
+
+    async def process_model_inputs_async(
         self,
-        request_id: str,  # pylint: disable=unused-argument
-        prompt: Optional[str],
-        prompt_token_ids: Optional[List[int]] = None,
+        request_id: str,
+        inputs: PromptInputs,
         lora_request: Optional[LoRARequest] = None,
-    ):
-        if prompt_token_ids is None:
-            assert prompt is not None
-            prompt_token_ids = await self.tokenizer.encode_async(
-                request_id=request_id, prompt=prompt, lora_request=lora_request
+    ) -> LLMInputs:
+        if isinstance(inputs, str):
+            inputs = {"prompt": inputs}
+
+        if "prompt_token_ids" not in inputs:
+            tokenizer = self.get_tokenizer_group(
+                "prompts must be None if " "skip_tokenizer_init is True"
             )
-        return prompt_token_ids
+
+            prompt_token_ids = await tokenizer.encode_async(
+                request_id=request_id,
+                prompt=inputs["prompt"],
+                lora_request=lora_request,
+            )
+        else:
+            prompt_token_ids = inputs["prompt_token_ids"]
+
+        return LLMInputs(
+            prompt_token_ids=prompt_token_ids,
+            prompt=inputs.get("prompt"),
+            multi_modal_data=inputs.get("multi_modal_data"),
+        )
 
     async def add_request_async(
         self,
         request_id: str,
-        prompt: Optional[str],
-        sampling_params: SamplingParams,
-        prompt_token_ids: Optional[List[int]] = None,
+        inputs: PromptInputs,
+        params: Union[SamplingParams, PoolingParams],
         arrival_time: Optional[float] = None,
         lora_request: Optional[LoRARequest] = None,
-        multi_modal_data: Optional[MultiModalData] = None,
     ) -> None:
         if lora_request is not None and not self.lora_config:
             raise ValueError(
@@ -352,21 +396,17 @@ class _AsyncLLMEngine(LLMEngine):
             )
         if arrival_time is None:
             arrival_time = time.time()
-        prompt_token_ids = await self.encode_request_async(
-            request_id=request_id,
-            prompt=prompt,
-            prompt_token_ids=prompt_token_ids,
-            lora_request=lora_request,
+
+        processed_inputs = await self.process_model_inputs_async(
+            request_id=request_id, inputs=inputs, lora_request=lora_request
         )
 
-        return self.add_request(
-            request_id,
-            prompt=prompt,
-            prompt_token_ids=prompt_token_ids,
-            sampling_params=sampling_params,
+        self._add_processed_request(
+            request_id=request_id,
+            processed_inputs=processed_inputs,
+            params=params,
             arrival_time=arrival_time,
             lora_request=lora_request,
-            multi_modal_data=multi_modal_data,
         )
 
     async def check_health_async(self) -> None:
@@ -374,15 +414,13 @@ class _AsyncLLMEngine(LLMEngine):
 
 
 class AsyncLLMEngine:
-    """An asynchronous wrapper for LLMEngine.
+    """An asynchronous wrapper for :class:`LLMEngine`.
 
-    This class is used to wrap the LLMEngine class to make it asynchronous. It
-    uses asyncio to create a background loop that keeps processing incoming
-    requests. The LLMEngine is kicked by the generate method when there
-    are requests in the waiting queue. The generate method yields the outputs
-    from the LLMEngine to the caller.
-
-    NOTE: For the comprehensive list of arguments, see `LLMEngine`.
+    This class is used to wrap the :class:`LLMEngine` class to make it
+    asynchronous. It uses asyncio to create a background loop that keeps
+    processing incoming requests. The :class:`LLMEngine` is kicked by the
+    generate method when there are requests in the waiting queue. The generate
+    method yields the outputs from the :class:`LLMEngine` to the caller.
 
     Args:
         worker_use_ray: Whether to use Ray for model workers. Required for
@@ -396,8 +434,8 @@ class AsyncLLMEngine:
             being printed in log.
         start_engine_loop: If True, the background task to run the engine
             will be automatically started in the generate call.
-        *args: Arguments for LLMEngine.
-        *kwargs: Arguments for LLMEngine.
+        *args: Arguments for :class:`LLMEngine`.
+        **kwargs: Arguments for :class:`LLMEngine`.
     """
 
     _engine_class: Type[_AsyncLLMEngine] = _AsyncLLMEngine
@@ -418,14 +456,16 @@ class AsyncLLMEngine:
         self.max_log_len = max_log_len
         self.engine = self._init_engine(*args, **kwargs)
 
-        self.background_loop = None
+        self.background_loop: Optional[asyncio.Future] = None
         # We need to keep a reference to unshielded
         # task as well to prevent it from being garbage
         # collected
-        self._background_loop_unshielded = None
+        self._background_loop_unshielded: Optional[asyncio.Task] = None
         self.start_engine_loop = start_engine_loop
-        self._request_tracker: Optional[RequestTracker] = None
         self._errored_with: Optional[BaseException] = None
+
+        # Lazy initialized fields
+        self._request_tracker: RequestTracker
 
     @classmethod
     def from_engine_args(
@@ -437,26 +477,39 @@ class AsyncLLMEngine:
         """Creates an async LLM engine from the engine arguments."""
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
+        distributed_executor_backend = (
+            engine_config.parallel_config.distributed_executor_backend
+        )
 
         if engine_config.device_config.device_type == "neuron":
-            raise NotImplementedError(
-                "Neuron is not supported for " "async engine yet."
-            )
-        elif engine_config.parallel_config.worker_use_ray:
+            from vllm.executor.neuron_executor import NeuronExecutorAsync
+
+            executor_class = NeuronExecutorAsync
+        elif engine_config.device_config.device_type == "cpu":
+            assert (
+                distributed_executor_backend is None
+            ), "Distributed execution is not supported with the CPU backend."
+            from vllm.executor.cpu_executor import CPUExecutorAsync
+
+            executor_class = CPUExecutorAsync
+        elif distributed_executor_backend == "ray":
             initialize_ray_cluster(engine_config.parallel_config)
             from vllm.executor.ray_gpu_executor import RayGPUExecutorAsync
 
             executor_class = RayGPUExecutorAsync
+        elif distributed_executor_backend == "mp":
+            from vllm.executor.multiproc_gpu_executor import (
+                MultiprocessingGPUExecutorAsync,
+            )
+
+            executor_class = MultiprocessingGPUExecutorAsync
         else:
-            assert (
-                engine_config.parallel_config.world_size == 1
-            ), "Ray is required if parallel_config.world_size > 1."
             from vllm.executor.gpu_executor import GPUExecutorAsync
 
             executor_class = GPUExecutorAsync
         # Create the async LLM engine.
         engine = cls(
-            engine_config.parallel_config.worker_use_ray,
+            distributed_executor_backend == "ray",
             engine_args.engine_use_ray,
             **engine_config.to_dict(),
             executor_class=executor_class,
@@ -472,13 +525,16 @@ class AsyncLLMEngine:
     def is_running(self) -> bool:
         return (
             self.background_loop is not None
+            and self._background_loop_unshielded is not None
             and not self._background_loop_unshielded.done()
         )
 
     @property
     def is_stopped(self) -> bool:
         return self.errored or (
-            self.background_loop is not None and self._background_loop_unshielded.done()
+            self.background_loop is not None
+            and self._background_loop_unshielded is not None
+            and self._background_loop_unshielded.done()
         )
 
     @property
@@ -494,7 +550,7 @@ class AsyncLLMEngine:
 
     async def get_tokenizer(self) -> "PreTrainedTokenizer":
         if self.engine_use_ray:
-            return await self.engine.get_tokenizer.remote()
+            return await self.engine.get_tokenizer.remote()  # type: ignore
         else:
             return self.engine.get_tokenizer()
 
@@ -513,7 +569,7 @@ class AsyncLLMEngine:
             self.run_engine_loop()
         )
         self._background_loop_unshielded.add_done_callback(
-            partial(_raise_exception_on_finish, error_callback=self._error_callback)
+            partial(_log_task_completion, error_callback=self._error_callback)
         )
         self.background_loop = asyncio.shield(self._background_loop_unshielded)
 
@@ -548,7 +604,7 @@ class AsyncLLMEngine:
             # TODO: Maybe add add_request_batch to reduce Ray overhead
             try:
                 if self.engine_use_ray:
-                    await self.engine.add_request.remote(**new_request)
+                    await self.engine.add_request.remote(**new_request)  # type: ignore
                 else:
                     await self.engine.add_request_async(**new_request)
             except ValueError as e:
@@ -563,7 +619,7 @@ class AsyncLLMEngine:
             await self._engine_abort(finished_requests)
 
         if self.engine_use_ray:
-            request_outputs = await self.engine.step.remote()
+            request_outputs = await self.engine.step.remote()  # type: ignore
         else:
             request_outputs = await self.engine.step_async()
 
@@ -577,7 +633,7 @@ class AsyncLLMEngine:
 
     async def _engine_abort(self, request_ids: Iterable[str]):
         if self.engine_use_ray:
-            await self.engine.abort_request.remote(request_ids)
+            await self.engine.abort_request.remote(request_ids)  # type: ignore
         else:
             self.engine.abort_request(request_ids)
 
@@ -604,27 +660,35 @@ class AsyncLLMEngine:
     async def add_request(
         self,
         request_id: str,
-        prompt: Optional[str],
-        sampling_params: SamplingParams,
-        prompt_token_ids: Optional[List[int]] = None,
+        inputs: PromptInputs,
+        params: Union[SamplingParams, PoolingParams],
         arrival_time: Optional[float] = None,
         lora_request: Optional[LoRARequest] = None,
-        multi_modal_data: Optional[MultiModalData] = None,
     ) -> AsyncStream:
         if self.log_requests:
-            shortened_prompt = prompt
-            shortened_token_ids = prompt_token_ids
-            if self.max_log_len is not None:
+            if isinstance(inputs, str):
+                shortened_prompt = inputs
+                shortened_token_ids = None
+            else:
+                shortened_prompt = inputs.get("prompt")
+                shortened_token_ids = inputs.get("prompt_token_ids")
+
+            max_log_len = self.max_log_len
+            if max_log_len is not None:
                 if shortened_prompt is not None:
-                    shortened_prompt = shortened_prompt[: self.max_log_len]
+                    shortened_prompt = shortened_prompt[:max_log_len]
                 if shortened_token_ids is not None:
-                    shortened_token_ids = shortened_token_ids[: self.max_log_len]
+                    shortened_token_ids = shortened_token_ids[:max_log_len]
+
             logger.info(
-                f"Received request {request_id}: "
-                f"prompt: {shortened_prompt!r}, "
-                f"sampling_params: {sampling_params}, "
-                f"prompt_token_ids: {shortened_token_ids}, "
-                f"lora_request: {lora_request}."
+                "Received request %s: prompt: %r, "
+                "params: %s, prompt_token_ids: %s, "
+                "lora_request: %s.",
+                request_id,
+                shortened_prompt,
+                params,
+                shortened_token_ids,
+                lora_request,
             )
 
         if not self.is_running:
@@ -642,40 +706,32 @@ class AsyncLLMEngine:
             arrival_time = time.time()
 
         if self.engine_use_ray:
-            prompt_token_ids = await self.engine.encode_request_async.remote(
-                request_id=request_id,
-                prompt=prompt,
-                prompt_token_ids=prompt_token_ids,
-                lora_request=lora_request,
+            processed_inputs = (
+                await self.engine.process_model_inputs_async.remote(  # type: ignore
+                    request_id=request_id, inputs=inputs, lora_request=lora_request
+                )
             )
         else:
-            prompt_token_ids = await self.engine.encode_request_async(
-                request_id=request_id,
-                prompt=prompt,
-                prompt_token_ids=prompt_token_ids,
-                lora_request=lora_request,
+            processed_inputs = await self.engine.process_model_inputs_async(
+                request_id=request_id, inputs=inputs, lora_request=lora_request
             )
 
         stream = self._request_tracker.add_request(
             request_id,
-            prompt=prompt,
-            sampling_params=sampling_params,
-            prompt_token_ids=prompt_token_ids,
+            inputs=processed_inputs,
+            params=params,
             arrival_time=arrival_time,
             lora_request=lora_request,
-            multi_modal_data=multi_modal_data,
         )
 
         return stream
 
     async def generate(
         self,
-        prompt: Optional[str],
+        inputs: PromptInputs,
         sampling_params: SamplingParams,
         request_id: str,
-        prompt_token_ids: Optional[List[int]] = None,
         lora_request: Optional[LoRARequest] = None,
-        multi_modal_data: Optional[MultiModalData] = None,
         tools_or_functions: Optional[List[dict]] = None,
         prompt_template_cls: Optional[Any] = None,
         tool_choice: Optional[Any] = None,
@@ -687,20 +743,158 @@ class AsyncLLMEngine:
         from the LLMEngine to the caller.
 
         Args:
-            prompt: The prompt string. Can be None if prompt_token_ids is
-                provided.
+            inputs: The inputs to the LLM. See
+                :class:`~vllm.inputs.PromptInputs`
+                for more details about the format of each input.
             sampling_params: The sampling parameters of the request.
             request_id: The unique id of the request.
-            prompt_token_ids: The token IDs of the prompt. If None, we
-                use the tokenizer to convert the prompts to token IDs.
             lora_request: LoRA request to use for generation, if any.
-            multi_modal_data: Multi modal data per request.
 
         Yields:
-            The output `RequestOutput` objects from the LLMEngine for the
-            request.
+            The output `RequestOutput` objects from the LLMEngine
+            for the request.
+
+        Details:
+            - If the engine is not running, start the background loop,
+              which iteratively invokes
+              :meth:`~vllm.engine.async_llm_engine.AsyncLLMEngine.engine_step`
+              to process the waiting requests.
+            - Add the request to the engine's `RequestTracker`.
+              On the next background loop, this request will be sent to
+              the underlying engine.
+              Also, a corresponding `AsyncStream` will be created.
+            - Wait for the request outputs from `AsyncStream` and yield them.
+
+        Example:
+            >>> # Please refer to entrypoints/api_server.py for
+            >>> # the complete example.
+            >>>
+            >>> # initialize the engine and the example input
+            >>> engine = AsyncLLMEngine.from_engine_args(engine_args)
+            >>> example_input = {
+            >>>     "prompt": "What is LLM?",
+            >>>     "stream": False, # assume the non-streaming case
+            >>>     "temperature": 0.0,
+            >>>     "request_id": 0,
+            >>> }
+            >>>
+            >>> # start the generation
+            >>> results_generator = engine.generate(
+            >>>    example_input["prompt"],
+            >>>    SamplingParams(temperature=example_input["temperature"]),
+            >>>    example_input["request_id"])
+            >>>
+            >>> # get the results
+            >>> final_output = None
+            >>> async for request_output in results_generator:
+            >>>     if await request.is_disconnected():
+            >>>         # Abort the request if the client disconnects.
+            >>>         await engine.abort(request_id)
+            >>>         # Return or raise an error
+            >>>         ...
+            >>>     final_output = request_output
+            >>>
+            >>> # Process and return the final output
+            >>> ...
         """
-        # Preprocess the request.
+        async for output in self._process_request(
+            request_id,
+            inputs,
+            sampling_params,
+            lora_request=lora_request,
+            tools_or_functions=tools_or_functions,
+            prompt_template_cls=prompt_template_cls,
+            tool_choice=tool_choice,
+        ):
+            yield LLMEngine.validate_output(output, RequestOutput)
+
+    async def encode(
+        self,
+        inputs: PromptInputs,
+        pooling_params: PoolingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> AsyncIterator[EmbeddingRequestOutput]:
+        """Generate outputs for a request from an embedding model.
+
+        Generate outputs for a request. This method is a coroutine. It adds the
+        request into the waiting queue of the LLMEngine and streams the outputs
+        from the LLMEngine to the caller.
+
+        Args:
+            inputs: The inputs to the LLM. See
+                :class:`~vllm.inputs.PromptInputs`
+                for more details about the format of each input.
+            pooling_params: The pooling parameters of the request.
+            request_id: The unique id of the request.
+            lora_request: LoRA request to use for generation, if any.
+
+        Yields:
+            The output `EmbeddingRequestOutput` objects from the LLMEngine
+            for the request.
+
+        Details:
+            - If the engine is not running, start the background loop,
+              which iteratively invokes
+              :meth:`~vllm.engine.async_llm_engine.AsyncLLMEngine.engine_step`
+              to process the waiting requests.
+            - Add the request to the engine's `RequestTracker`.
+              On the next background loop, this request will be sent to
+              the underlying engine.
+              Also, a corresponding `AsyncStream` will be created.
+            - Wait for the request outputs from `AsyncStream` and yield them.
+
+        Example:
+            >>> # Please refer to entrypoints/api_server.py for
+            >>> # the complete example.
+            >>>
+            >>> # initialize the engine and the example input
+            >>> engine = AsyncLLMEngine.from_engine_args(engine_args)
+            >>> example_input = {
+            >>>     "input": "What is LLM?",
+            >>>     "request_id": 0,
+            >>> }
+            >>>
+            >>> # start the generation
+            >>> results_generator = engine.encode(
+            >>>    example_input["input"],
+            >>>    PoolingParams(),
+            >>>    example_input["request_id"])
+            >>>
+            >>> # get the results
+            >>> final_output = None
+            >>> async for request_output in results_generator:
+            >>>     if await request.is_disconnected():
+            >>>         # Abort the request if the client disconnects.
+            >>>         await engine.abort(request_id)
+            >>>         # Return or raise an error
+            >>>         ...
+            >>>     final_output = request_output
+            >>>
+            >>> # Process and return the final output
+            >>> ...
+        """
+        async for output in self._process_request(
+            request_id,
+            inputs,
+            pooling_params,
+            lora_request=lora_request,
+        ):
+            yield LLMEngine.validate_output(output, EmbeddingRequestOutput)
+
+    async def _process_request(
+        self,
+        request_id: str,
+        inputs: PromptInputs,
+        params: Union[SamplingParams, PoolingParams],
+        *,
+        lora_request: Optional[LoRARequest] = None,
+        tools_or_functions: Optional[List[dict]] = None,
+        prompt_template_cls: Optional[Any] = None,
+        tool_choice: Optional[Any] = None,
+    ) -> AsyncIterator[Union[RequestOutput, EmbeddingRequestOutput]]:
+        """Common logic to process requests with SamplingParams or
+        PoolingParams."""
         arrival_time = time.time()
 
         # Initialize the request_id entry of self.engine.tools_or_functions
@@ -751,22 +945,18 @@ class AsyncLLMEngine:
             ),
         )
 
-        try:
-            stream = await self.add_request(
-                request_id,
-                prompt,
-                sampling_params,
-                prompt_token_ids=prompt_token_ids,
-                arrival_time=arrival_time,
-                lora_request=lora_request,
-                multi_modal_data=multi_modal_data,
-            )
+        stream = await self.add_request(
+            request_id,
+            inputs,
+            params,
+            arrival_time=arrival_time,
+            lora_request=lora_request,
+        )
 
+        try:
             async for request_output in stream:
                 yield request_output
         except (Exception, asyncio.CancelledError) as e:
-            # If there is an exception or coroutine is cancelled, abort the
-            # request.
             self._abort(request_id)
 
             # Delete request_id entry from self.engine before raising error
@@ -814,13 +1004,26 @@ class AsyncLLMEngine:
     async def get_model_config(self) -> ModelConfig:
         """Get the model configuration of the vLLM engine."""
         if self.engine_use_ray:
-            return await self.engine.get_model_config.remote()
+            return await self.engine.get_model_config.remote()  # type: ignore
         else:
             return self.engine.get_model_config()
 
-    async def do_log_stats(self) -> None:
+    async def get_decoding_config(self) -> DecodingConfig:
+        """Get the decoding configuration of the vLLM engine."""
         if self.engine_use_ray:
-            await self.engine.do_log_stats.remote()
+            return await self.engine.get_decoding_config.remote()  # type: ignore
+        else:
+            return self.engine.get_decoding_config()
+
+    async def do_log_stats(
+        self,
+        scheduler_outputs: Optional[SchedulerOutputs] = None,
+        model_output: Optional[List[SamplerOutput]] = None,
+    ) -> None:
+        if self.engine_use_ray:
+            await self.engine.do_log_stats.remote(  # type: ignore
+                scheduler_outputs, model_output
+            )
         else:
             self.engine.do_log_stats()
 
@@ -833,9 +1036,9 @@ class AsyncLLMEngine:
 
         if self.engine_use_ray:
             try:
-                await self.engine.check_health.remote()
+                await self.engine.check_health.remote()  # type: ignore
             except ray.exceptions.RayActorError as e:
                 raise RuntimeError("Engine is dead.") from e
         else:
             await self.engine.check_health_async()
-        logger.debug(f"Health check took {time.perf_counter()-t}s")
+        logger.debug("Health check took %fs", time.perf_counter() - t)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
 transformers==4.40.1
 accelerate~=0.21.0
 sentencepiece~=0.1.99
-fastapi~=0.104.0
+fastapi~=0.111.0
 uvicorn~=0.23.1
 pydantic~=2.6.0
 scipy~=1.11.1
 jsonref~=1.1.0
 requests~=2.31.0
 PyYAML~=6.0.1
-typer==0.9.0
 protobuf==3.20.0
 tokenizers==0.19.1
-vllm==0.4.1; sys_platform != "darwin"
+vllm==0.5.0; sys_platform != "darwin"

--- a/server_vllm.py
+++ b/server_vllm.py
@@ -26,11 +26,7 @@ import uvicorn
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.entrypoints.openai.protocol import (
-    ModelCard,
-    ModelList,
-    ModelPermission,
-)
+from vllm.entrypoints.openai.protocol import ModelCard, ModelList, ModelPermission
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer import get_tokenizer
 


### PR DESCRIPTION
Main changes:
- `engine.generate()` takes in `inputs` which combines `prompt`, `prompt_token_ids`, etc. other parameters. Pass in `vllm.inputs.TokensPrompt` typeddict object now
- Moved preprocessing stuff needed for grammar sampling to `AsyncLLMEngine._process_request` helper method instead of inside `AsyncLLMEngine.generate` main method. Grammar sampling logic in `_AsyncLLMEngine.step_async` remains the same. Everything else in async_llm_engine.py monkey patch is copy-pasted entirely from vllm.
- Upgraded fastapi to v0.111.0 too due to starlette dependency conflict with vllm when keeping fastapi to v0.104.0
- Removed `LogProbs` stuff in server_vllm.py as we no longer need it and vLLM also have some revamp to LogProbs such that it is no longer in `vllm.entrypoints.openai.protocol`
- Removed `args.served_model_name` as vllm seems to be validating `EngineArgs` now and raises error for conflicting arguments if we add arguments in our server_vllm.py that have the same names as any of the attributes in [EngineArgs](https://github.com/vllm-project/vllm/blob/main/vllm/engine/arg_utils.py#L24) class.