### PR TITLE
Add vLLM's health and metrics endpoints

### DIFF
--- a/server_vllm.py
+++ b/server_vllm.py
@@ -24,9 +24,11 @@ from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, Un
 
 import fastapi
 import uvicorn
+import vllm.entrypoints.openai.api_server as vllm_api_server
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
 from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.entrypoints.openai.api_server import health, mount_metrics
 from vllm.entrypoints.openai.protocol import ModelCard, ModelList, ModelPermission
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer import get_tokenizer
@@ -44,6 +46,12 @@ logger.addHandler(logging.StreamHandler())
 
 served_model = []
 app = fastapi.FastAPI()
+
+
+@app.get("/health")
+async def _health():
+    """Health check."""
+    return await health()
 
 
 @app.get("/v1/models")
@@ -128,6 +136,8 @@ if __name__ == "__main__":
     else:
         from vllm.engine.async_llm_engine import AsyncLLMEngine
 
+    mount_metrics(app)
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=args.allowed_origins,
@@ -153,6 +163,9 @@ if __name__ == "__main__":
 
     engine = AsyncLLMEngine.from_engine_args(engine_args)
     engine_model_config = asyncio.run(engine.get_model_config())
+
+    # Adapt to vLLM's health endpoint
+    vllm_api_server.async_engine_client = engine
 
     uvicorn.run(
         app,


### PR DESCRIPTION
Fix #260 

- `/health`: reuse vLLM's endpoint with a reassigned variable.
- `/metrics`: reuse vLLM's endpoint using [`mount_metrics`](https://github.com/vllm-project/vllm/blob/v0.5.4/vllm/entrypoints/openai/api_server.py#L137).